### PR TITLE
$VIMRPLUGIN_TMPDIR is preferentially created in $TMPDIR

### DIFF
--- a/r-plugin/common_global.vim
+++ b/r-plugin/common_global.vim
@@ -3080,11 +3080,14 @@ if v:servername != ""
     let $VIMEDITOR_SVRNM = v:servername
 endif
 
-if isdirectory("/tmp")
+if isdirectory($TMPDIR)
+    let $VIMRPLUGIN_TMPDIR = $TMPDIR . "/r-plugin-" . g:rplugin_userlogin
+elseif isdirectory("/tmp")
     let $VIMRPLUGIN_TMPDIR = "/tmp/r-plugin-" . g:rplugin_userlogin
 else
     let $VIMRPLUGIN_TMPDIR = g:rplugin_uservimfiles . "/r-plugin/tmp"
 endif
+
 let g:rplugin_esc_tmpdir = substitute($VIMRPLUGIN_TMPDIR, ' ', '\\ ', 'g')
 
 if !isdirectory($VIMRPLUGIN_TMPDIR)


### PR DESCRIPTION
Avoids problems when /tmp is not available or non-writeable. $TMPDIR (if set) is vim's preferred directory for temporary files, see :help tempfile.
In my specific case, vim and R run on two different hosts (R is executed on a remote host via a wrapper script) that mount the same filesystem for /home but not for /tmp. This results in vimcom complaining that '/tmp/r-plugin-username/vimcom_running is not writeable.
